### PR TITLE
Develop

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,14 +11,16 @@ Replace String with JSON format
 2) Structured streaming
 The same flow from Twitter to Kafka and Spark. ELK stack is not used, the data is displayed on the console format (for now). Fields to be discovered:
 - Filtering and aggregations on data (implemented)
-- Windowed aggregations (in process)
-- Watermarking
+- Windowed aggregations (implemented with count, other aggregations are in process)
+- Watermarking (implemented)
+- Data deduplication (in process)
 - Metrics gathering
 
 Future plans:
 - Upgrade Spark to 2.4.0
+- Multiple streams joins
 - Replace Kafka producer String format with JSON format for the legacy Spark streaming case
 - ELK stack introduction for Spark structured streaming case
-- Deploy the project on Kubernetes
+- Deploy the project with Kubernetes
 
 Spark 2.3.1 is used for now. Scala version is current release (2.12.8)

--- a/README.md
+++ b/README.md
@@ -8,22 +8,22 @@ The project consists of 2 parts:
 Simple data flow from data producer (Kafka) to consumer (Spark). The data format is simple String which is further stored in ES.
 
 Implementation plans:
-Replace String with JSON format (implemented)
+- ~~Replace String with JSON format~~
+- ~~Replace Kafka producer String format with JSON format for the legacy Spark streaming case~~ 
 
 2) **Structured streaming**
 
 The same flow from Twitter to Kafka and Spark. ELK stack is not used, the data is displayed on the console format (for now). Fields to be discovered:
-- Filtering and aggregations on data (implemented)
-- Windowed aggregations (implemented with count, other aggregations are in process)
-- Watermarking (implemented)
-- Data deduplication (in process)
+- ~~Filtering and aggregations on data~~
+- ~~Windowed aggregations~~
+- ~~Watermarking~~ 
+- Data deduplication (IN PROGRESS)
 - Metrics gathering
 
 **Future plans:**
-- Upgrade Spark to 2.4.0
+- ~~Upgrade Spark to 2.4.0~~
 - Multiple streams joins
-- Replace Kafka producer String format with JSON format for the legacy Spark streaming case
 - ELK stack introduction for Spark structured streaming case
 - Deploy the project with Kubernetes
 
-Spark 2.3.1 is used for now. Scala version is current release (2.12.8)
+Spark 2.4.0 is used with Scala version is current release (2.12.8)

--- a/README.md
+++ b/README.md
@@ -3,12 +3,15 @@ ElasticSearch and Kibana are used to store and display the data (respectively).
 
 The project consists of 2 parts:
 
-1) Legacy streaming
-Simple data flow from data producer (Kafka) to consumer (Spark). The data format is simple String which is further stored in ES.
-Further implementation plans:
-Replace String with JSON format
+1) **Legacy streaming**
 
-2) Structured streaming
+Simple data flow from data producer (Kafka) to consumer (Spark). The data format is simple String which is further stored in ES.
+
+Implementation plans:
+Replace String with JSON format (implemented)
+
+2) **Structured streaming**
+
 The same flow from Twitter to Kafka and Spark. ELK stack is not used, the data is displayed on the console format (for now). Fields to be discovered:
 - Filtering and aggregations on data (implemented)
 - Windowed aggregations (implemented with count, other aggregations are in process)
@@ -16,7 +19,7 @@ The same flow from Twitter to Kafka and Spark. ELK stack is not used, the data i
 - Data deduplication (in process)
 - Metrics gathering
 
-Future plans:
+**Future plans:**
 - Upgrade Spark to 2.4.0
 - Multiple streams joins
 - Replace Kafka producer String format with JSON format for the legacy Spark streaming case

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ version := "0.1"
 
 scalaVersion := "2.11.8"
 
-val sparkVersion = "2.3.1"
+val sparkVersion = "2.4.0"
 
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-core" % "2.9.6"
 dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.9.6"

--- a/src/main/scala/utils/SparkSqlFunctionsTemplates.scala
+++ b/src/main/scala/utils/SparkSqlFunctionsTemplates.scala
@@ -3,8 +3,6 @@ package utils
 import org.apache.spark.sql.functions.{max, min}
 import org.apache.spark.sql.types.{ArrayType, DataTypes, StructType}
 import org.apache.spark.sql.{DataFrame, Dataset, Row}
-import java.sql.Timestamp
-import java.text.SimpleDateFormat
 
 
 class SparkSqlFunctionsTemplates {


### PR DESCRIPTION
String Kafka Producer for legacy streaming is replaced with the JSON Kafka Producer. Data in Spark legacy consumer is transformed into a dataframe.  Spark is updated to 2.4.0. So the README file is updated according to the project progress.